### PR TITLE
Base64 directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ which replaces the one-time example above.
 
 With a deployed sshephalopod and a configured Okta:
 
+* Ensure you're using gnu base64. If not, run `ln -s /usr/local/bin/gbase64 /usr/local/bin/base64`
 * Have an SSH public key in `$HOME/.ssh/id_rsa.pub`
 * Run the wrapper script:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ which replaces the one-time example above.
 
 With a deployed sshephalopod and a configured Okta:
 
-* Ensure you're using gnu base64. If not, run `ln -s /usr/local/bin/gbase64 /usr/local/bin/base64`
+* For OSX users, make sure you're using gnu base64. Install coreutils: `brew install coreutils`. Ensure your base64 is mapped to gbase64: `ln -s /usr/local/bin/gbase64 /usr/local/bin/base64`
 * Have an SSH public key in `$HOME/.ssh/id_rsa.pub`
 * Run the wrapper script:
 


### PR DESCRIPTION
For OSX users, base64 commands with -d and -w are mapped differently.
