### PR TITLE
Hacking multi-tenancy in

### DIFF
--- a/lambda/SigningRequestPassport.js
+++ b/lambda/SigningRequestPassport.js
@@ -62,7 +62,7 @@ exports.handler = function(event, context) {
 
 
     var bucketName = event.KeypairBucket;
-    var keyName = event.KeypairName;
+    var keyName = event.body.Hostname + "-sshephalopod-ca";
     var realName = 'REAL-NAME-HERE';
     var tempdir;
     var db_params = {
@@ -92,6 +92,7 @@ exports.handler = function(event, context) {
         },
         function parseConfig(cfgJSON, next) {
             config = JSON.parse(cfgJSON);
+            config = config[event.body.Hostname];
 
             // check some basic things
             if (parseInt(config.signatureDuration)) {

--- a/lambda/SigningRequestPassport.js
+++ b/lambda/SigningRequestPassport.js
@@ -92,7 +92,15 @@ exports.handler = function(event, context) {
         },
         function parseConfig(cfgJSON, next) {
             config = JSON.parse(cfgJSON);
-            config = config[event.body.Hostname];
+            if (event.body.Hostname in config["aliases"]) {
+              console.log(event.body.Hostname + " is an alias for " + config["aliases"][event.body.Hostname]);
+              config = config[config["aliases"][event.body.Hostname]];
+            } else {
+              config = config[event.body.Hostname];
+            }
+
+            console.log("Effective Configuration:", JSON.stringify(config));
+
 
             // check some basic things
             if (parseInt(config.signatureDuration)) {

--- a/lambda/ca-stack.json
+++ b/lambda/ca-stack.json
@@ -1,0 +1,69 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "SSHephalopod is an SSH Certificate Authority",
+
+  "Parameters": {
+    "DNSDomain": {
+      "Description": "The DNS domain that will be hosting sshephalopod",
+      "Type": "String"
+    },
+    "CAKeyPairBucket": {
+      "Description": "The name of the S3 bucket that will store the CA keypair",
+      "Type": "String"
+    },
+    "CAKeyPairKeyname": {
+      "Description": "The name of the keypair in the S3 bucket",
+      "Type": "String"
+    },
+    "MakeKeypairFunctionARN": {
+      "Description": "ARN of the lambda function that creates a keypair",
+      "Type": "String"
+    }
+  },
+
+  "Resources": {
+    "CAKeyPair": {
+      "Type": "Custom::GeneratedCAKeyPair",
+      "Properties": {
+        "ServiceToken": {"Ref":"MakeKeypairFunctionARN"},
+        "Bucket": { "Ref": "CAKeyPairBucket" },
+        "Key": {"Fn::Join": [ "", [{ "Ref": "CAKeyPairKeyname" }, ".", {"Ref":"DNSDomain"}, "-sshephalopod-ca" ] ] },
+        "MeaninglessThings": "cheese"
+      }
+    },
+
+    "SSHephalopodTXT": {
+      "Type": "AWS::Route53::RecordSet",
+      "Properties": {
+        "Comment": "DNS records for sshephalopod",
+        "HostedZoneName": {
+          "Fn::Join": [
+            "",
+            [ { "Ref": "DNSDomain" }, "." ]
+          ]
+        },
+        "Name": {
+          "Fn::Join": [
+            "",
+            [ "sshephalopod-ca-cert", ".", {"Ref":"CAKeyPairKeyname"}, ".", { "Ref": "DNSDomain" }, "." ]
+          ]
+        },
+        "Type": "TXT",
+        "TTL": "300",
+        "ResourceRecords": [
+          { "Fn::Join": [
+            "", [
+              "\"",
+              { "Fn::GetAtt": [ "CAKeyPair", "PublicKey" ] },
+              "\""
+            ]
+          ]}
+        ]
+      }
+    }
+  },
+
+  "Outputs": {
+    "CAPublicKey": { "Value": { "Fn::GetAtt": [ "CAKeyPair", "PublicKey" ] } }
+  }
+}

--- a/lambda/config.json
+++ b/lambda/config.json
@@ -1,12 +1,26 @@
 {
-  "sshOptions": [
-    "no-agent-forwarding",
-    "no-user-rc",
-    "no-x11-forwarding"
-  ],
-  "signatureDuration": 43200,
-  "groups": {
-    "GroupName1": [ "ec2-user", "ubuntu" ],
-    "GroupName2": [ "ec2-user" ]
-  }
+	"ca-number-one.example.com": {
+		"sshOptions": [
+			"no-agent-forwarding",
+			"no-user-rc",
+			"no-x11-forwarding"
+		],
+		"signatureDuration": 43200,
+		"groups": {
+			"GroupName1": [ "ec2-user", "ubuntu" ],
+			"GroupName2": [ "ec2-user", "ubuntu" ]
+		}
+	},
+	"ca-number-two.example.com": {
+		"sshOptions": [
+			"no-agent-forwarding",
+			"no-user-rc",
+			"no-x11-forwarding"
+		],
+		"signatureDuration": 43200,
+		"groups": {
+			"GroupName1": [ "ec2-user", "ubuntu" ],
+			"GroupName2": [ "ec2-user", "ubuntu" ]
+		}
+	}
 }

--- a/lambda/config.json
+++ b/lambda/config.json
@@ -1,4 +1,7 @@
 {
+	"aliases": {
+		"another-ca.example.com": "ca-number-one.example.com"
+	},
 	"ca-number-one.example.com": {
 		"sshOptions": [
 			"no-agent-forwarding",

--- a/lambda/create-ca.sh
+++ b/lambda/create-ca.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+if [ $# -ne 4 ]; then
+    echo $#
+    echo "usage: $0 <keypair-bucket> <dns-domain> <keypair-name> <make-ca-arn>"
+    exit 1
+fi
+
+
+export BUCKET=$1
+export DNSDOMAIN=$2
+export KP_NAME=$3
+export FUNCTION_ARN=$4
+
+echo $KP_NAME
+
+LAMBDA_STACK="sshephalopod-ca-${KP_NAME}"
+
+
+log () {
+    date "+%Y-%m-%d %H:%M:%S $1"
+}
+
+die () {
+    echo "FATAL: $1"
+    exit 1
+}
+
+wait_completion () {
+    local STACK=$1
+    echo -n "Waiting for stack $STACK to complete:"
+    while true; do
+        local STATUS=$( aws cloudformation describe-stack-events \
+            --stack-name $STACK \
+            --query 'StackEvents[].{x: ResourceStatus, y: ResourceType}' \
+            --output text | \
+            grep "AWS::CloudFormation::Stack" | head -n 1 | awk '{ print $1 }'
+        )
+        case $STATUS in
+            UPDATE_COMPLETE_CLEANUP_IN_PROGRESS)    : ;;
+            UPDATE_COMPLETE|CREATE_COMPLETE)
+                echo "stack $STACK complete"
+                return 0 ;;
+            *ROLLBACK*)
+                echo "stack $STACK rolling back"
+                return 1 ;;
+            FAILED)
+                echo "ERROR updating stack"
+                return 1 ;;
+            "")
+                echo "No output while looking for stack completion"
+                return 1 ;;
+            *) : ;;
+        esac
+        echo -n "."
+        sleep 5
+    done
+}
+
+create_lambda_stack () {
+    local STACK=$1
+    log "Creating stack $STACK"
+    local OUT=$( aws cloudformation create-stack \
+        --stack-name $LAMBDA_STACK \
+        --template-body file://ca-stack.json \
+        --parameters \
+            "ParameterKey=DNSDomain,ParameterValue=$DNSDOMAIN" \
+            "ParameterKey=CAKeyPairBucket,ParameterValue=$BUCKET" \
+            "ParameterKey=CAKeyPairKeyname,ParameterValue=$KP_NAME" \
+            "ParameterKey=MakeKeypairFunctionARN,ParameterValue=$FUNCTION_ARN"
+    )
+    wait_completion $STACK || return 1
+}
+
+update_lambda_stack () {
+    local STACK=$1
+    log "Updating stack $STACK"
+    local OUT=$( aws cloudformation update-stack \
+        --stack-name $LAMBDA_STACK \
+        --template-body file://ca-stack.json \
+        --parameters \
+            "ParameterKey=DNSDomain,ParameterValue=$DNSDOMAIN" \
+            "ParameterKey=CAKeyPairBucket,ParameterValue=$BUCKET" \
+            "ParameterKey=CAKeyPairKeyname,ParameterValue=$KP_NAME" \
+            "ParameterKey=MakeKeypairFunctionARN,ParameterValue=$FUNCTION_ARN"
+    )
+    wait_completion $STACK || return 1
+}
+
+# Create the stack of the Lambda function
+if [ -z "$( aws cloudformation describe-stacks --stack-name $LAMBDA_STACK 2>/dev/null )" ]; then
+    create_lambda_stack $LAMBDA_STACK || die "Can't create stack"
+else
+    update_lambda_stack $LAMBDA_STACK || die "Can't update stack"
+fi
+
+log "Complete"

--- a/lambda/sshephalopod.json
+++ b/lambda/sshephalopod.json
@@ -190,45 +190,6 @@
       }
     },
 
-    "CAKeyPair": {
-      "Type": "Custom::GeneratedCAKeyPair",
-      "Properties": {
-        "ServiceToken": { "Fn::GetAtt": [ "SSHephalopodKeyPair", "Arn" ] },
-        "Bucket": { "Ref": "CAKeyPairBucket" },
-        "Key": { "Ref": "CAKeyPairKeyname" },
-        "MeaninglessThings": "cheese"
-      }
-    },
-
-    "SSHephalopodTXT": {
-      "Type": "AWS::Route53::RecordSet",
-      "Properties": {
-        "Comment": "DNS records for sshephalopod",
-        "HostedZoneName": {
-          "Fn::Join": [
-            "",
-            [ { "Ref": "DNSDomain" }, "." ]
-          ]
-        },
-        "Name": {
-          "Fn::Join": [
-            "",
-            [ "sshephalopod-ca-cert", ".", { "Ref": "DNSDomain" }, "." ]
-          ]
-        },
-        "Type": "TXT",
-        "TTL": "300",
-        "ResourceRecords": [
-          { "Fn::Join": [
-            "", [
-              "\"",
-              { "Fn::GetAtt": [ "CAKeyPair", "PublicKey" ] },
-              "\""
-            ]
-          ]}
-        ]
-      }
-    },
 
     "SSHephalopodSRV": {
       "Type": "AWS::Route53::RecordSet",
@@ -485,7 +446,6 @@
   },
 
   "Outputs": {
-    "CAPublicKey": { "Value": { "Fn::GetAtt": [ "CAKeyPair", "PublicKey" ] } },
     "GenerateMetadata": { "Value": { "Fn::GetAtt": [ "GenerateMetadata", "Arn" ] } },
     "SigningRequest": { "Value": { "Fn::GetAtt": [ "SigningRequestPassport", "Arn" ] } },
     "SigningPreAuth": { "Value": { "Fn::GetAtt": [ "SigningPreAuth", "Arn" ] } },


### PR DESCRIPTION
Alright,

I was looking into deploying into one of our accounts when I decided to attempt making it multi-tenancy, or rather, host multiple CAs in one deployment. Turns out, on the signing side of things, it was a 2 line change, and nesting the config struct in a hash.

On the CA generation wise, I split out the CA Generation CustomResource and the TXT record into it's own stack.

We end up with

## SSHephalopod Deployment

- CA Generation Lambda
- PreAuth Gateway + Function
- Signing Gateway + Function
- SRV record that points to the API Gateway endpoint.

## SSHephalopod CA deployment

One stack per managed CA.
- Call to the CA generation
- Create a TXT record with the key name on Route53

So, if the central deployment is, for example, `my-sshephalopod-deployment.example.com`, and we create a CA deployment for `my-first-ca`, we'll end up with DNS entries like this:

- `_sshephalopod._tcp.sshephalopod-deployment.example.com IN SRV x y z API-GATEWAY...`
- `my-first-ca.my-sshphalopod-deployment.example.com IN TXT ssh-rsa ...`

Now. The beauty of DNS means that when trying to get a cert, users make DNS queries that will respect CNAMES.

- `_sshephalopod._tcp.somewhereelse.com IN CNAME _sshephalopod._tcp.sshephalopod-deployment.example.com`
`my-first-ca.somewhereelse.com IN CNAME my-first-ca.my-sshphalopod-deployment.example.com`

The users of the CA deployment ca create CNAMEs, that point to the central deployment, and sshephalopod still works! (on my server side and client side clients, anyway)

Thoughts?